### PR TITLE
Fixes around the middleware against recently discovered edge cases

### DIFF
--- a/marshaller/main.go
+++ b/marshaller/main.go
@@ -72,22 +72,38 @@ func Unmarshal(v js.Value) *gojs.Value {
 	return m
 }
 
-func parseObjectToSlice(obj js.Value) []interface{} {
-	var s []interface{}
+func parseObjectToSlice(obj js.Value) []*gojs.Value {
+	var s []*gojs.Value
 
 	for i := 0; i < obj.Length(); i++ {
 		val := obj.Index(i)
 
 		switch val.Type() {
 		case js.TypeNumber:
-			s = append(s, val.Float())
+			s = append(s, &gojs.Value{
+				Type:        gojs.TypeNumber,
+				Constructor: "Number",
+				Value:       val.Float(),
+			})
 		case js.TypeBoolean:
-			s = append(s, val.Bool())
+			s = append(s, &gojs.Value{
+				Type:        gojs.TypeBoolean,
+				Constructor: "Boolean",
+				Value:       val.Bool(),
+			})
 		case js.TypeString:
-			s = append(s, val.String())
+			s = append(s, &gojs.Value{
+				Type:        gojs.TypeString,
+				Constructor: "String",
+				Value:       val.String(),
+			})
 		case js.TypeObject:
 			if val.Get("constructor").Get("name").String() == "Array" {
-				s = append(s, parseObjectToSlice(val))
+				s = append(s, &gojs.Value{
+					Type:        gojs.TypeArray,
+					Constructor: val.Get("constructor").Get("name").String(),
+					Value:       parseObjectToSlice(val),
+				})
 				continue
 			}
 			s = append(s, Unmarshal(val))

--- a/middleware.go
+++ b/middleware.go
@@ -178,8 +178,8 @@ func WASMMiddleware_v2(this js.Value, args []js.Value) interface{} {
 		return nil
 	}))
 
-	// OVERWRITE THE SEND FUNCTION
-	res.Set("send", js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+	// OVERWRITE ALL RESPONSE FUNCTIONS
+	respond := js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 		// we'll need to convert some of the args to a map
 		// this is for instances where the user wants to send a json response
 		// and the args are stringified json
@@ -208,8 +208,10 @@ func WASMMiddleware_v2(this js.Value, args []js.Value) interface{} {
 			"data": base64.URLEncoding.EncodeToString(response.Body),
 		})))
 		return nil
-	}))
+	})
 
+	res.Set("send", respond)
+	res.Set("json", respond)
 	return nil
 }
 


### PR DESCRIPTION
## Description

This PR fixes some issues caused by previously undiscovered edge cases, they are:
- Sending an array of data fails because the middleware is not properly unmarshalling slice-formatted request data
- When a service provider responds back to a request using the express `.json` method, it fails because it was not overridden like the `.send` method

## A test suite of simple manual tests to ensure functionality is preserved.

SECTION 1: WEVE GOT POEMS (http://localhost:5173/)
- [x] Log in with 'tester' / '1234'
- [x] Log in anonymously with Layer8
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login screen
- [x] Clicking "Register" takes you to the registration page
- [x] Registering with a username, password, and profile image is successful
- [x] Logging in with the new username / password succeeds
- [x] Logging in with Layer8 opens the pop-up
- [x] Logging in with the "tester" & "12341234" works
- [x] User chooses to share their new "Username" & "Country" from the Layer8 Resource Server
- [x] Clicking "Get Next Poem" loads different poem correctly x 3
- [x] Clicking "Logout" takes you to the login page

SECTION 2: IMSHARER (http://localhost:5174/)
- [x] Main page loads
- [x] Upload of image works
- [x] Reload leads to instant reload (demonstrating proper caching)
- [x] Clicking the newly loaded image shows it in a light boxLog in using tester and 12341234 should succeed
